### PR TITLE
PTM-73: Add global properties to control how many patients to process

### DIFF
--- a/api/src/main/java/org/regenstrief/linkage/io/OpenMRSReader.java
+++ b/api/src/main/java/org/regenstrief/linkage/io/OpenMRSReader.java
@@ -18,13 +18,16 @@ import org.hibernate.SessionFactory;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.PersonAttributeType;
+import org.openmrs.api.context.Context;
 import org.openmrs.module.patientmatching.HibernateConnection;
 import org.openmrs.module.patientmatching.LinkDBConnections;
 import org.regenstrief.linkage.Record;
 
 public class OpenMRSReader implements DataSourceReader {
 
-    private final int PAGING_SIZE = 10000;
+    private final int PAGING_SIZE = Context.getAdministrationService().getGlobalPropertyValue("patientmatching.scratchPageSize", Integer.valueOf(10000)).intValue();
+    
+    private final int PAGING_LIMIT = Context.getAdministrationService().getGlobalPropertyValue("patientmatching.scratchPageLimit", Integer.valueOf(-1)).intValue();
 
     protected final Log log = LogFactory.getLog(this.getClass());
     
@@ -220,7 +223,7 @@ public class OpenMRSReader implements DataSourceReader {
      * @see org.regenstrief.linkage.io.DataSourceReader#hasNextRecord()
      */
     public boolean hasNextRecord() {
-    	if(patients.size() == 0) {
+    	if((patients.size() == 0) && ((PAGING_LIMIT <= 0) || ((pageNumber + 1) < PAGING_LIMIT))) {
     		pageNumber ++;
     		updatePatientList();
     	}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -54,6 +54,15 @@
 		<defaultValue>http://link.regenstrief.org:8080/openmrs/admin/patients/mergePatients.form</defaultValue>
 		<description>URL pointing to the production server </description>
 	</globalProperty>
+	<globalProperty>
+        <property>patientmatching.scratchPageSize</property>
+        <defaultValue>10000</defaultValue>
+        <description>The number of patients to read per page</description>
+    </globalProperty>
+    <globalProperty>
+        <property>patientmatching.scratchPageLimit</property>
+        <description>The number of pages to read</description>
+    </globalProperty>
 	
 	<dwr>
 		<allow>


### PR DESCRIPTION
While investigating performance issues, Burke said that we should add global properties to control the number of records that the patient matching module should process.  This pull request will add that feature.