### PR TITLE
Add error message to the Patient Matching module

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientmatching/PatientMatchingActivator.java
+++ b/api/src/main/java/org/openmrs/module/patientmatching/PatientMatchingActivator.java
@@ -226,7 +226,7 @@ public class PatientMatchingActivator extends StaticMethodMatcherPointcutAdvisor
                 try {
                     Context.getSchedulerService().shutdownTask(td);
                 } catch (SchedulerException e) {
-                    log.error("Exception caught while shutting down Patient Matching Module ...", e);
+                    log.error("SchedulerException caught while shutting down Patient Matching Module ...", e);
                 }
             }
         }

--- a/api/src/main/java/org/openmrs/module/patientmatching/PatientMatchingActivator.java
+++ b/api/src/main/java/org/openmrs/module/patientmatching/PatientMatchingActivator.java
@@ -226,8 +226,7 @@ public class PatientMatchingActivator extends StaticMethodMatcherPointcutAdvisor
                 try {
                     Context.getSchedulerService().shutdownTask(td);
                 } catch (SchedulerException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                    log.error("Exception caught while shutting down Patient Matching Module ...", e);
                 }
             }
         }


### PR DESCRIPTION
Adds meaningful error message to exception thrown when patient matching activator module is being shut down.

Couldn't find any other catch instances that were missing error messages. Let me know if there are more.