### PR TITLE
PTM-104: Fix the unexpected failure during spring bean definition parsing

### DIFF
--- a/api/src/main/java/org/openmrs/module/patientmatching/db/hibernate/HibernatePatientMatchingReportMetadataDAO.java
+++ b/api/src/main/java/org/openmrs/module/patientmatching/db/hibernate/HibernatePatientMatchingReportMetadataDAO.java
@@ -9,7 +9,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.Query;
-import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.Cohort;

--- a/api/src/main/java/org/openmrs/module/patientmatching/impl/PatientMatchingReportMetadataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/patientmatching/impl/PatientMatchingReportMetadataServiceImpl.java
@@ -26,14 +26,14 @@ public class PatientMatchingReportMetadataServiceImpl implements PatientMatching
 	/**
 	 * setter for PatientMatchingReportMetadataDAO
 	 */
-	public void setPatientMatchingReportMetadataDao(PatientMatchingReportMetadataDao dao) {
+	public void setDao(PatientMatchingReportMetadataDao dao) {
 		this.dao = dao;
 	}
 	
 	/**
 	 * getter for PatientMatchingReportMetadataDAO
 	 */
-	public PatientMatchingReportMetadataDao getPatientMatchingReportMetadataDao() {
+	public PatientMatchingReportMetadataDao getDao() {
 		return dao;
 	}
 	

--- a/omod/src/main/resources/moduleApplicationContext.xml
+++ b/omod/src/main/resources/moduleApplicationContext.xml
@@ -88,36 +88,32 @@
 		</property>
 	</bean>
 
+	<bean id="patientMatchingReportMetadataService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager"><ref bean="transactionManager"/></property>
+		<property name="target">
+			<ref bean="patientMatchingReportMetadataServiceImpl"/>
+		</property>
+		<property name="preInterceptors">
+			<ref bean="serviceInterceptors"/>
+		</property>
+		<property name="transactionAttributeSource">
+			<bean class="org.springframework.transaction.annotation.AnnotationTransactionAttributeSource"/>
+		</property>
+	</bean>
+
+	<bean id="patientMatchingReportMetadataServiceImpl" class="org.openmrs.module.patientmatching.impl.PatientMatchingReportMetadataServiceImpl">
+		<property name="dao">
+			<bean class="org.openmrs.module.patientmatching.db.hibernate.HibernatePatientMatchingReportMetadataDAO">
+				<property name="sessionFactory" ref="dbSessionFactory"/>
+			</bean>
+		</property>
+	</bean>
+
 	<bean parent="serviceContext">
 		<property name="moduleService">
 			<list>
 				<value>org.openmrs.module.patientmatching.PatientMatchingReportMetadataService</value>
-				<bean
-					class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
-					<property name="transactionManager">
-						<ref bean="transactionManager" />
-					</property>
-					<property name="target">
-						<bean
-							class="org.openmrs.module.patientmatching.impl.PatientMatchingReportMetadataServiceImpl">
-							<property name="PatientMatchingReportMetadataDao">
-								<bean
-									class="org.openmrs.module.patientmatching.db.hibernate.HibernatePatientMatchingReportMetadataDAO">
-									<property name="sessionFactory">
-										<ref bean="dbSessionFactory" />
-									</property>
-								</bean>
-							</property>
-						</bean>
-					</property>
-					<property name="preInterceptors">
-						<ref bean="serviceInterceptors" />
-					</property>
-					<property name="transactionAttributeSource">
-						<bean
-							class="org.springframework.transaction.annotation.AnnotationTransactionAttributeSource" />
-					</property>
-				</bean>
+				<ref bean="patientMatchingReportMetadataService"/>
 			</list>
 		</property>
 	</bean>


### PR DESCRIPTION
### Ticket worked on
https://issues.openmrs.org/browse/PTM-104

It's just a bug fix. There is a mismatch between the class property name and getters & setter i.e `private PatientMatchingReportMetadataDao dao;` and the setter `setPatientMatchingReportMetadataDao(PatientMatchingReportMetadataDao dao);`. Instead it should be;
```java
 private PatientMatchingReportMetadataDao dao;
	
 public void setDao(PatientMatchingReportMetadataDao dao) {
    this.dao = dao;
 }

 public PatientMatchingReportMetadataDao getDao() {
    return dao;
 }
```
or use `patientMatchingReportMetadataDao` for property-name. Either way, they should be consistent.

cc: @dkayiwa | @ibacher 